### PR TITLE
Allow localhost domains, as defined in the Secure Contexts W3C spec

### DIFF
--- a/dist/chromium/manifest.json
+++ b/dist/chromium/manifest.json
@@ -7,7 +7,7 @@
   "content_scripts": [
     {
       "all_frames": true,
-      "matches": ["https://*/*"],
+      "matches": ["https://*/*", "http://localhost/*", "http://*.localhost/*", "http://127.0.0.1/*", "http://[::1]/*"],
       "run_at": "document_start",
       "js": ["js/content_script.js"],
       "css": ["content_script.css"]

--- a/dist/firefox/manifest.json
+++ b/dist/firefox/manifest.json
@@ -12,7 +12,7 @@
   "content_scripts": [
     {
       "all_frames": true,
-      "matches": ["https://*/*"],
+      "matches": ["https://*/*", "http://localhost/*", "http://*.localhost/*", "http://127.0.0.1/*", "http://[::1]/*"],
       "run_at": "document_start",
       "js": ["js/content_script.js"],
       "css": ["content_script.css"]


### PR DESCRIPTION
[Secure Contexts, Section 3.2](https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy)
