### PR TITLE
Remove invalid tokenBinding field from clientData

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -161,9 +161,6 @@ async function handle_webauthn_register(msg: any,
         clientExtensions: {},
         hashAlgorithm: 'SHA-256',
         origin,
-        tokenBinding: {
-            status: 'not-supported',
-        },
         type: 'webauthn.create',
     });
     const clientDataB64 = await to_base64_url_nopad(clientData);


### PR DESCRIPTION
From the spec: https://www.w3.org/TR/webauthn/#dom-collectedclientdata-tokenbinding

The tokenBinding.status member must be one of the following: "supported", "present".

Its absence indicates that the client doesn’t support token binding.

Fixes #29 