### PR TITLE
use hostname instead of host to strip the ports

### DIFF
--- a/src/origin-checker.ts
+++ b/src/origin-checker.ts
@@ -48,7 +48,7 @@ export function checkIsRegistrableDomainSuffix(origin: string, hostSuffixString:
         return false;
     }
     const originUrl = new URL(origin);
-    const originalHost = originUrl.host;
+    const originalHost = originUrl.hostname;
     const host = hostSuffixString;
     if (host !== originalHost) {
         const hostLspl = getLeastSpecificPrivateLabel(host);


### PR DESCRIPTION
Per the specs here: https://www.w3.org/TR/webauthn/#relying-party-identifier
>For example, given a Relying Party whose origin is https://login.example.com:1337, then the following RP IDs are valid: login.example.com (default) and example.com, but not m.login.example.com and not com.

Fix #41 