### PR TITLE
Update GitLab 2FA page url

### DIFF
--- a/dist/KryptonAuthenticator.safariextension/popup.html
+++ b/dist/KryptonAuthenticator.safariextension/popup.html
@@ -124,7 +124,7 @@
           <span class='status fix'>NOT SECURED</span>
         </div>
       </a>
-      <a href='https://gitlab.com/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
+      <a href='https://gitlab.com/-/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
         <div class="cell unsecured" id="gl">
 
           <img class='icon' src='img/logos/gitlab.png' />

--- a/dist/chromium/popup.html
+++ b/dist/chromium/popup.html
@@ -128,7 +128,7 @@
           <span class='status fix'>NOT SECURED</span>
         </div>
       </a>
-      <a href='https://gitlab.com/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
+      <a href='https://gitlab.com/-/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
         <div class="cell unsecured" id="gl">
 
           <img class='icon' src='img/logos/gitlab.png' />

--- a/dist/edge/KryptonAuthenticator/edgeextension/manifest/Extension/popup.html
+++ b/dist/edge/KryptonAuthenticator/edgeextension/manifest/Extension/popup.html
@@ -128,7 +128,7 @@
           <span class='status fix'>NOT SECURED</span>
         </div>
       </a>
-      <a href='https://gitlab.com/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
+      <a href='https://gitlab.com/-/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
         <div class="cell unsecured" id="gl">
 
           <img class='icon' src='img/logos/gitlab.png' />

--- a/dist/firefox/popup.html
+++ b/dist/firefox/popup.html
@@ -128,7 +128,7 @@
           <span class='status fix'>NOT SECURED</span>
         </div>
       </a>
-      <a href='https://gitlab.com/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
+      <a href='https://gitlab.com/-/profile/two_factor_auth' target='_blank' rel='noopener noreferrer'>
         <div class="cell unsecured" id="gl">
 
           <img class='icon' src='img/logos/gitlab.png' />


### PR DESCRIPTION
GitLab 2FA configuration page has moved from `https://gitlab.com/profile/two_factor_auth` to `https://gitlab.com/-/profile/two_factor_auth`.